### PR TITLE
不要なパーミッションを削除

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -17,8 +17,6 @@
   "options_page": "options.html",
   "permissions": [
     "tabs",
-    "webNavigation",
-    "history",
     "scripting"
   ],
   "host_permissions": [

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -110,8 +110,7 @@ chrome.tabs.onHighlighted.addListener(async (highlightInfo) => {
 // タブ内frameに何らかの変更があったときに発火(status:loading, complete と title:hogeを拾う)
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     if (changeInfo.hasOwnProperty('audible') || changeInfo.hasOwnProperty('favIconUrl')) { return }
-
-    const [current] = (await chrome.history.search({text: '', maxResults: 1}));
+    const [current] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
     if (tab.url !== current.url) {
         return
     }


### PR DESCRIPTION
historyのパーミッションを使うことなく現在のタブが取れることがわかったので、Tabs APIから取得するように変更

webNavigation, historyのパーミッションを消すことで「閲覧履歴の読み取りと変更」の権限が要らなくなる